### PR TITLE
CI: move `CI` env variable to the root of the workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Tests
 on: [push, pull_request]
+env:
+  CI: true
 
 jobs:
   run:
@@ -25,8 +27,6 @@ jobs:
 
       - name: Install npm dependencies
         run: npm ci
-        env:
-          CI: true
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
This way we match the Travis CI behavior, and it's inherited by all steps.