### PR TITLE
Construct the valid extensions from the valid MIME types

### DIFF
--- a/src/process-html.js
+++ b/src/process-html.js
@@ -4,14 +4,9 @@ const path = require('path')
 const fs = require('fs')
 const cheerio = require('cheerio')
 const pretty = require('pretty')
-const { processImage } = require('./process-image')
+const { processImage, supportedMimetypes } = require('./process-image')
 
-const validImgExtensions = [
-  '.jpg',
-  '.jpeg',
-  '.png',
-  '.gif'
-]
+const validImgExtensions = Object.keys(supportedMimetypes).map(ext => `.${ext}`)
 
 const processHtml = (file, config) => new Promise((resolve, reject) => {
   const { rootPath, attribute, srcAttr, pretty: prettyHtml } = config

--- a/src/process-image.js
+++ b/src/process-image.js
@@ -29,5 +29,6 @@ const processImage = (pathImg, originalImg) => new Promise((resolve, reject) => 
 })
 
 module.exports = {
-  processImage
+  processImage,
+  supportedMimetypes
 }


### PR DESCRIPTION
@Johann-S if you have any other idea let me know :) This reduces the duplication, but we sort of do the opposite in process-image